### PR TITLE
Запрещаем расширение класса клиента

### DIFF
--- a/src/SkolkovoClient.php
+++ b/src/SkolkovoClient.php
@@ -16,7 +16,7 @@ use Ruwork\SkolkovoClient\Definition\SkolkovoDefinition;
  * @method ContextBuilder\Oauth\TokenPasswordContextBuilder oauthTokenPassword()
  * @method ContextBuilder\Oauth\TokenRefreshContextBuilder oauthTokenRefresh()
  */
-class SkolkovoClient extends AbstractApiClient
+final class SkolkovoClient extends AbstractApiClient
 {
     public function __construct(array $defaultContext = [], $extensions = [], SkolkovoDefinition $definition = null)
     {


### PR DESCRIPTION
В общем случае данное расширение не возможно, лучше запретить, думаю, что бы разработчики не тратили время на поиск проблем и её решения. Вполне комфортно пользоваться и без этого. 